### PR TITLE
docs: Add github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!--
+  While filling all of these sections out is optional, it's highly recommended
+  that you fill out context and objective; it doesn't need to be extremely detailed
+-->
+
 ## Context
 
 <!-- Why do we need this PR? What was the reason that led you to make this change? -->


### PR DESCRIPTION
## Context

Github templates enables you to add a default template users can fill out when making PRs or issues. Adding a template to your project establishes a minimal guideline for developers to follow when making contributions.

## Objective

* Add a pull request template

## References

* Issue: https://github.com/ScottyFillups/haxwheels/issues/3