### PR TITLE
fix: Change Parcel --public-url to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "test": "standard",
     "fix": "standard --fix",
-    "build": "parcel build ./client/index.html --public-url '.' --out-dir 'static/'",
+    "build": "parcel build ./client/index.html --public-url '.' --out-dir static",
     "dev": "nodemon ./bin/server",
     "precommit": "yarn run test"
   },


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

app.js accesses files from ./static directory. Surrounding this in directory in single quotations breaks the path so app.js cannot find the files built by parcel.

## Objective

This fix modifies the build script by removing the quotations for parcel's targetted build location.