### PR TITLE
fix: Display updated position to player

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,7 +8,7 @@ const room = client.join('race')
 
 console.log('Client JavaScript loaded!')
 
-room.listen('players/:id/:attribute', (change) => {
+room.listen('players/:id/position/:attribute', (change) => {
   console.log(change.path.id, change.path.attribute, change.value)
 })
 


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

Currently the client doesn't `console.log` mutations in state, only the addition of state.

## Objective

* Fixes bug described above

## Lessons learned

* The listener path for Colyseus needs to be an exact match in structure