### PR TITLE
feat(28): Make controls more responsive

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -11,12 +11,12 @@ const controller = new Controller(room, virtuals)
 const view = new View()
 
 const keymap = {
-  up: 'up',
-  down: 'down',
-  left: 'left',
-  right: 'right'
+  up: ['ArrowUp', 'w'],
+  down: ['ArrowDown', 's'],
+  left: ['ArrowLeft', 'a'],
+  right: ['ArrowRight', 'd']
 }
-controller.register(keymap)
 
+controller.register(keymap)
 room.listen('players/:id', change => view.updatePlayer(change))
 room.listen('players/:id/position/:attribute', change => view.updatePosition(change))

--- a/client/virtuals.js
+++ b/client/virtuals.js
@@ -1,24 +1,23 @@
-const virtuals = {
-  up: {
+const directions = ['up', 'down', 'left', 'right']
+let virtuals = {}
+
+directions.forEach((key) => {
+  virtuals[key] = {
     keydown (model) {
-      model.send({move: 'up'})
-    }
-  },
-  down: {
-    keydown (model) {
-      model.send({move: 'down'})
-    }
-  },
-  left: {
-    keydown (model) {
-      model.send({move: 'left'})
-    }
-  },
-  right: {
-    keydown (model) {
-      model.send({move: 'right'})
+      console.log(key, true)
+      let data = {}
+      data[key] = true
+
+      model.send(data)
+    },
+    keyup (model) {
+      console.log(key, false)
+      let data = {}
+      data[key] = false
+
+      model.send(data)
     }
   }
-}
+})
 
 export default virtuals

--- a/game/math/cardinal.js
+++ b/game/math/cardinal.js
@@ -1,0 +1,18 @@
+class Cardinal {
+  constructor (directions) {
+    this.set(directions)
+  }
+
+  // filter keys to NSEW
+  set ({ n, s, e, w }) {
+    const directions = { n, s, e, w }
+
+    for (const key in directions) {
+      if (directions[key] !== undefined) {
+        this[key] = directions[key]
+      }
+    }
+  }
+}
+
+module.exports = Cardinal

--- a/game/math/index.js
+++ b/game/math/index.js
@@ -1,5 +1,7 @@
 const Point2 = require('./point')
+const Cardinal = require('./cardinal')
 
 module.exports = {
-  Point2
+  Point2,
+  Cardinal
 }

--- a/game/math/point.js
+++ b/game/math/point.js
@@ -1,5 +1,8 @@
 class Point2 {
   constructor (x, y) {
+    this.set(x, y)
+  }
+  set (x, y) {
     this.x = x
     this.y = y
   }

--- a/game/player.js
+++ b/game/player.js
@@ -1,8 +1,14 @@
-const { Point2 } = require('./math')
+const { Cardinal, Point2 } = require('./math')
 
 class Player {
   constructor (x, y) {
     this.position = new Point2(x, y)
+    this.movement = new Cardinal({
+      n: false,
+      w: false,
+      e: false,
+      s: false
+    })
   }
 }
 

--- a/game/rooms/race.js
+++ b/game/rooms/race.js
@@ -6,6 +6,27 @@ class RaceRoom extends Room {
     this.setState({
       players: {}
     })
+    this.setSimulationInterval(this.update.bind(this))
+  }
+
+  update () {
+    for (const playerId in this.state.players) {
+      const step = 3
+      const player = this.state.players[playerId]
+
+      if (player.movement.n) {
+        player.position.y -= step
+      }
+      if (player.movement.s) {
+        player.position.y += step
+      }
+      if (player.movement.e) {
+        player.position.x += step
+      }
+      if (player.movement.w) {
+        player.position.x -= step
+      }
+    }
   }
 
   onJoin (client) {
@@ -15,24 +36,16 @@ class RaceRoom extends Room {
   }
 
   onMessage (client, data) {
-    const step = 10
     const player = this.state.players[client.sessionId]
 
-    console.log('Message received!', data)
+    console.log(`Message received from ${client.sessionId}!`)
 
-    switch (data.move) {
-      case 'left':
-        player.position.x -= step
-        break
-      case 'right':
-        player.position.x += step
-        break
-      case 'up':
-        player.position.y -= step
-        break
-      case 'down':
-        player.position.y += step
-    }
+    player.movement.set({
+      n: data.up,
+      s: data.down,
+      e: data.right,
+      w: data.left
+    })
   }
 
   onLeave (client) {

--- a/test/game/math.test.js
+++ b/test/game/math.test.js
@@ -4,7 +4,7 @@
 
 require('module-alias/register')
 
-const { Point2 } = require('@game/math')
+const { Point2, Cardinal } = require('@game/math')
 const { expect } = require('chai')
 
 describe('math library', () => {
@@ -25,5 +25,98 @@ describe('math library', () => {
       expect(p.x).to.equal(42)
       expect(p.y).to.equal(2000)
     })
+  })
+
+  describe('Cardinal class', () => {
+    it('has the correct values when instantiated', () => {
+      const c = new Cardinal({
+        n: true,
+        s: false,
+        w: true,
+        e: true
+      })
+
+      expect(c.n).to.equal(true)
+      expect(c.s).to.equal(false)
+      expect(c.w).to.equal(true)
+      expect(c.e).to.equal(true)
+    })
+
+    it('constructor filters out non-cardinal keys', () => {
+      const c = new Cardinal({
+        n: true,
+        s: false,
+        w: true,
+        e: true,
+        wew: true,
+        hehe: true
+      })
+
+      expect(c.n).to.equal(true)
+      expect(c.s).to.equal(false)
+      expect(c.w).to.equal(true)
+      expect(c.e).to.equal(true)
+      expect(c.wew).to.equal(undefined)
+      expect(c.hehe).to.equal(undefined)
+    })
+
+    it('has the correct values when fields are mutated', () => {
+      const c = new Cardinal({
+        n: true,
+        s: false,
+        w: true,
+        e: true
+      })
+
+      c.n = false
+      c.s = true
+
+      expect(c.n).to.equal(false)
+      expect(c.s).to.equal(true)
+    })
+
+    it('Cardinal.set(...) will only set members if not undefined', () => {
+      const c = new Cardinal({
+        n: false,
+        s: false,
+        w: true,
+        e: true
+      })
+
+      c.set({
+        n: true,
+        s: true,
+        w: undefined,
+        e: undefined
+      })
+
+      expect(c.n).to.equal(true)
+      expect(c.s).to.equal(true)
+      expect(c.w).to.equal(true)
+      expect(c.e).to.equal(true)
+    })
+  })
+
+  it('Cardination.set(...) will filter out non-cardinal keys', () => {
+    const c = new Cardinal({
+      n: false,
+      s: false,
+      w: true,
+      e: true
+    })
+
+    c.set({
+      n: true,
+      s: true,
+      wew: true,
+      lad: true
+    })
+
+    expect(c.n).to.equal(true)
+    expect(c.s).to.equal(true)
+    expect(c.w).to.equal(true)
+    expect(c.e).to.equal(true)
+    expect(c.wew).to.equal(undefined)
+    expect(c.lad).to.equal(undefined)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,8 +3458,8 @@ jsx-ast-utils@^2.0.1:
     array-includes "^3.0.3"
 
 key-controller@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/key-controller/-/key-controller-1.0.0.tgz#0afffbe995a2bbeeb62d6b89fd27a6f81534c9ae"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/key-controller/-/key-controller-1.3.0.tgz#1121ebccdb9ff3c25aa30c17ae17494076176b31"
 
 keycode@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

Currently positions are determined by firing keyboard events on the client-side. This is problematic because:

* It causes very choppy movement (there is a delay between the first event and subsequent events)
* It restricts players to moving in one direction at a time
* There is no way to control how frequently a client fires a keyboard event (ie. no way to enforce maximum speed)

## Objective

* Update `key-controller` package to `1.3.0`
* Add `Cardinal` class, which stores booleans for NSEW (North, South, East, West)
* Give `Player` a `Cardinal` object; `player.movement`
  * The client will fire messages changing the state of `player.movement`
  * The game loop will check `player.movement`, and mutate the position accordingly
* Compute positions in a game loop

## References

* Issue: https://github.com/ScottyFillups/haxwheels/issues/28