### PR TITLE
fix: Add start NPM script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "yarn run lint && nyc mocha --require babel-core/register --recursive test/*",
     "build": "parcel build ./client/index.html --public-url /static --out-dir static",
     "dev": "nodemon ./bin/server",
+    "start": "./bin/server",
     "prepush": "yarn run test"
   },
   "standard": {


### PR DESCRIPTION
<!--
  While filling all of these sections out is optional, it's highly recommended
  that you fill out context and objective; it doesn't need to be extremely detailed
-->

## Context

Heroku cannot start the Node application, since there is no `start` script.

## Objective

* Add a `start` script, such that the app can be run via `yarn run start`

## Lessons learned

* Before deploying to Heroku, testing should likely be done using Heroku local